### PR TITLE
WIP: Heatmap x axis options

### DIFF
--- a/packages/charts/src/chart_types/heatmap/layout/config/config.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/config/config.ts
@@ -63,6 +63,8 @@ export const config: Config = {
     align: 'center' as CanvasTextAlign,
     baseline: 'verticalAlign' as CanvasTextBaseline,
     padding: 6,
+    labelRotation: 0,
+    position: 'top',
     formatter: String,
   },
   yAxisLabel: {

--- a/packages/charts/src/chart_types/heatmap/layout/types/config_types.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/types/config_types.ts
@@ -19,7 +19,7 @@
 
 import { Pixels, SizeRatio } from '../../../../common/geometry';
 import { Font, FontFamily, TextAlign, TextBaseline } from '../../../../common/text_utils';
-import { Color } from '../../../../utils/common';
+import { Color, Rotation } from '../../../../utils/common';
 import { Cell } from './viewmodel_types';
 
 /**
@@ -64,6 +64,8 @@ export interface Config {
     baseline: TextBaseline;
     visible: boolean;
     padding: number;
+    labelRotation: Rotation;
+    position: 'top' | 'bottom';
     formatter: (value: string | number) => string;
   };
   yAxisLabel: Font & {

--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
@@ -170,7 +170,7 @@ export function shapeViewModel(
       x: chartDimensions.left + (scaleCallback(value) || 0),
       y:
         (config.xAxisLabel.position === 'top' ? 0 : cellHeight * pageSize) +
-        config.xAxisLabel.fontSize / 2 +
+        (Math.abs(config.xAxisLabel.labelRotation) === 90 ? 0 : config.xAxisLabel.fontSize / 2) +
         config.xAxisLabel.padding,
     };
   };

--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
@@ -68,14 +68,15 @@ function getValuesInRange(
 function getTicks(chartWidth: number, xAxisLabelConfig: Config['xAxisLabel']): number {
   const bboxCompute = new CanvasTextBBoxCalculator();
   const labelSample = xAxisLabelConfig.formatter(Date.now());
-  const { width } = bboxCompute.compute(
+  // TODO - use width or height depending on x axis tick label rotation
+  const { height } = bboxCompute.compute(
     labelSample,
     xAxisLabelConfig.padding,
     xAxisLabelConfig.fontSize,
     xAxisLabelConfig.fontFamily,
   );
   bboxCompute.destroy();
-  const maxTicks = Math.floor(chartWidth / width);
+  const maxTicks = Math.floor(chartWidth / height);
   // Dividing by 2 is a temp fix to make sure {@link ScaleContinuous} won't produce
   // to many ticks creating nice rounded tick values
   // TODO add support for limiting the number of tick in {@link ScaleContinuous}

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Font } from '../../../../common/text_utils';
+import { Font, TextAlign } from '../../../../common/text_utils';
 import { clearCanvas, renderLayers, withContext } from '../../../../renderers/canvas';
 import { renderMultiLine } from '../../../xy_chart/renderer/canvas/primitives/line';
 import { renderRect } from '../../../xy_chart/renderer/canvas/primitives/rect';
@@ -153,6 +153,13 @@ export function renderCanvas2d(
           if (!config.xAxisLabel.visible) {
             return;
           }
+          const labelRot = config.xAxisLabel.labelRotation;
+          let textAlign: TextAlign = 'center';
+          if (labelRot === 90) {
+            textAlign = 'left';
+          } else if (labelRot === -90) {
+            textAlign = 'right';
+          }
           heatmapViewModel.xValues.forEach((xValue) => {
             renderText(
               ctx,
@@ -161,8 +168,8 @@ export function renderCanvas2d(
                 y: xValue.y,
               },
               xValue.text,
-              { ...config.xAxisLabel, align: 'left' },
-              90,
+              { ...config.xAxisLabel, align: textAlign },
+              config.xAxisLabel.labelRotation,
             );
           });
         }),

--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -161,7 +161,8 @@ export function renderCanvas2d(
                 y: xValue.y,
               },
               xValue.text,
-              config.xAxisLabel,
+              { ...config.xAxisLabel, align: 'left' },
+              90,
             );
           });
         }),

--- a/packages/charts/src/chart_types/heatmap/renderer/dom/highlighter.tsx
+++ b/packages/charts/src/chart_types/heatmap/renderer/dom/highlighter.tsx
@@ -51,7 +51,6 @@ export const HighlighterCellsComponent: FC<HighlighterCellsProps> = ({
   if (!initialized || dragShape === null) return null;
 
   const maskId = `echHighlighterMask__${chartId}`;
-
   return (
     <svg className="echHighlighter" width="100%" height="100%">
       <defs>
@@ -59,7 +58,7 @@ export const HighlighterCellsComponent: FC<HighlighterCellsProps> = ({
           {brushMask.visible && (
             <rect
               x={0}
-              y={0}
+              y={canvasDimension.top}
               width={canvasDimension.width + canvasDimension.left}
               height={canvasDimension.height}
               fill="#eee"
@@ -89,7 +88,7 @@ export const HighlighterCellsComponent: FC<HighlighterCellsProps> = ({
         {brushMask.visible && (
           <rect
             x={0}
-            y={0}
+            y={canvasDimension.top}
             width={canvasDimension.width + canvasDimension.left}
             height={canvasDimension.height}
             mask={`url(#${maskId})`}

--- a/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
@@ -65,11 +65,11 @@ export const computeChartDimensionsSelector = createCustomCachedSelector(
     heatmapTable,
     config,
     rightOverflow,
-    { height },
+    { height, gridCellHeight, pageSize },
     { showLegend, legendPosition },
   ): Dimensions => {
     let { width, left } = chartContainerDimensions;
-    const { top } = chartContainerDimensions;
+    let { top } = chartContainerDimensions;
     const { padding } = config.yAxisLabel;
 
     const textMeasurer = document.createElement('canvas');
@@ -105,6 +105,11 @@ export const computeChartDimensionsSelector = createCustomCachedSelector(
       legendWidth = legendSize.width - legendSize.margin * 2;
     }
     width -= legendWidth;
+
+    if (config.xAxisLabel.position === 'top') {
+      // move the top down to make space for the x axis labels
+      top = chartContainerDimensions.height - gridCellHeight * pageSize - legendSize.height;
+    }
 
     return {
       height,

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_grid_full_height.test.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_grid_full_height.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Store } from 'redux';
+
+import { MockSeriesSpec } from '../../../../mocks/specs/specs';
+import { MockStore } from '../../../../mocks/store/store';
+import { ScaleType } from '../../../../scales/constants';
+import { GlobalChartState } from '../../../../state/chart_state';
+import { HeatmapSpec } from '../../specs';
+import { getGridHeightParamsSelector } from './get_grid_full_height';
+
+const basicSpec: Pick<HeatmapSpec, 'id' | 'data'> &
+  Partial<Omit<HeatmapSpec, 'chartType' | 'specType' | 'id' | 'data'>> = {
+  id: 'heatmap_id',
+  xScaleType: ScaleType.Ordinal,
+  data: [
+    { x: '1234', y: 'ya', value: 1 },
+    { x: '2345', y: 'ya', value: 2 },
+    { x: '3456', y: 'ya', value: 3 },
+    { x: '1234', y: 'yb', value: 4 },
+    { x: '2345', y: 'yb', value: 5 },
+    { x: '3456', y: 'yb', value: 6 },
+    { x: '2345', y: 'yc', value: 7 },
+    { x: '1234', y: 'yc', value: 8 },
+    { x: '2345', y: 'yc', value: 9 },
+    { x: '2345', y: 'yd', value: 7 },
+    { x: '1234', y: 'yd', value: 8 },
+    { x: '2345', y: 'yd', value: 9 },
+    { x: '2345', y: 'ye', value: 7 },
+    { x: '1234', y: 'ye', value: 8 },
+    { x: '2345', y: 'ye', value: 9 },
+    { x: '2345', y: 'yf', value: 7 },
+    { x: '1234', y: 'yf', value: 8 },
+    { x: '2345', y: 'yf', value: 9 },
+    { x: '2345', y: 'yg', value: 7 },
+    { x: '1234', y: 'yg', value: 8 },
+    { x: '2345', y: 'yg', value: 9 },
+  ],
+  xAccessor: (d: any) => d.x,
+  yAccessor: (d: any) => d.y,
+  valueAccessor: (d: any) => d.value,
+  config: {
+    grid: {
+      cellHeight: { max: 'fill' },
+    },
+    xAxisLabel: {
+      visible: true,
+    },
+    yAxisLabel: {
+      visible: true,
+    },
+    margin: { top: 0, bottom: 0, left: 0, right: 0 },
+  },
+};
+describe('Calculating Grid Height', () => {
+  let store: Store<GlobalChartState>;
+
+  beforeEach(() => {
+    store = MockStore.default({ width: 300, height: 200, top: 0, left: 0 }, 'chartId');
+  });
+
+  it('should give rotated text enough space', () => {
+    MockStore.addSpecs(
+      [
+        MockSeriesSpec.heatmap({
+          ...basicSpec,
+          config: {
+            xAxisLabel: {
+              labelRotation: 90,
+            },
+          },
+        }),
+      ],
+      store,
+    );
+    const result = getGridHeightParamsSelector(store.getState());
+    expect(result.height).toBe(156);
+  });
+  it('should give not rotated text enough space', () => {
+    MockStore.addSpecs(
+      [
+        MockSeriesSpec.heatmap({
+          ...basicSpec,
+          config: {
+            xAxisLabel: {
+              labelRotation: 0,
+            },
+          },
+        }),
+      ],
+      store,
+    );
+    const result = getGridHeightParamsSelector(store.getState());
+    expect(result.height).toBe(176);
+  });
+});

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_grid_full_height.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_grid_full_height.ts
@@ -58,24 +58,32 @@ export const getGridHeightParamsSelector = createCustomCachedSelector(
     // where the x axis height gets taken into account
 
     // TODO - only do all of this when the x axis tick labels are rotated
-    const xValues = table.map((entry) => entry.x);
-    const formattedXValues = xValues.map(config.xAxisLabel.formatter);
-    const boxedXValues = formattedXValues.map<Box & { value: string | number }>((value) => {
-      return {
-        text: String(value),
-        value,
-        ...config.xAxisLabel,
-      };
-    });
-    // console.log('formattedXValues:', formattedXValues);
-    const textMeasurer = document.createElement('canvas');
-    const textMeasurerCtx = textMeasurer.getContext('2d');
-    const textMeasure = measureText(textMeasurerCtx!);
+    const { labelRotation } = config.xAxisLabel;
 
-    const measuredXValues = textMeasure(config.xAxisLabel.fontSize, boxedXValues);
-    const xAxisHeightMeasured: number = d3Max(measuredXValues, ({ width }) => width) ?? 0;
-    // const xAxisHeight = visible ? fontSize : 0;
-    const xAxisHeight = config.xAxisLabel.visible ? xAxisHeightMeasured : 0;
+    let xAxisHeight = 0;
+    if (config.xAxisLabel.visible) {
+      if (Math.abs(labelRotation) === 90) {
+        const xValues = table.map((entry) => entry.x);
+        const formattedXValues = xValues.map(config.xAxisLabel.formatter);
+        const boxedXValues = formattedXValues.map<Box & { value: string | number }>((value) => {
+          return {
+            text: String(value),
+            value,
+            ...config.xAxisLabel,
+          };
+        });
+
+        const textMeasurer = document.createElement('canvas');
+        const textMeasurerCtx = textMeasurer.getContext('2d');
+        const textMeasure = measureText(textMeasurerCtx!);
+
+        const measuredXValues = textMeasure(config.xAxisLabel.fontSize, boxedXValues);
+        xAxisHeight = d3Max(measuredXValues, ({ width }) => width) ?? 0;
+      } else {
+        xAxisHeight = config.xAxisLabel.fontSize;
+      }
+    }
+
     const totalVerticalPadding = config.xAxisLabel.padding * 2;
     let legendHeight = 0;
     if (showLegend && isHorizontalLegend(legendSize.position)) {

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_tooltip_anchor.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_tooltip_anchor.ts
@@ -36,7 +36,7 @@ export const getTooltipAnchorSelector = createCustomCachedSelector(
       return {
         x: firstShape.x + chartDimensions.left,
         width: firstShape.width,
-        y: firstShape.y - chartDimensions.top,
+        y: firstShape.y + chartDimensions.top,
         height: firstShape.height,
       };
     }

--- a/stories/heatmap/1_basic.tsx
+++ b/stories/heatmap/1_basic.tsx
@@ -18,7 +18,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { boolean, button } from '@storybook/addon-knobs';
+import { boolean, button, select } from '@storybook/addon-knobs';
 import React, { useCallback, useMemo, useState } from 'react';
 import { debounce } from 'ts-debounce';
 
@@ -42,6 +42,9 @@ export const Example = () => {
   const debugState = boolean('Enable debug state', true);
   const dataStateAction = action('DataState');
   const xAxisVisible = boolean('X Axis visible', true);
+  const xAxisLabelRotation = select('X Axis Label Rotation', [0, 90, -90, 180], 0);
+  const xAxisPosition = select('X Axis Position', ['top', 'bottom'], 'top');
+  const showLegend = boolean('Show Legend', false);
   const handler = useCallback(() => {
     setSelection(undefined);
   }, []);
@@ -77,6 +80,8 @@ export const Example = () => {
       },
       xAxisLabel: {
         visible: xAxisVisible,
+        labelRotation: xAxisLabelRotation,
+        position: xAxisPosition,
         formatter: (value: string | number) => {
           return niceTimeFormatter([1572825600000, 1572912000000])(value, { timeZone: 'UTC' });
         },
@@ -85,7 +90,7 @@ export const Example = () => {
         setSelection({ x: e.x, y: e.y });
       }) as Config['onBrushEnd'],
     }),
-    [xAxisVisible],
+    [xAxisVisible, xAxisLabelRotation, xAxisPosition],
   );
 
   const logDebugstate = debounce(() => {
@@ -113,7 +118,7 @@ export const Example = () => {
       <Settings
         onElementClick={onElementClick}
         onRenderChange={logDebugstate}
-        showLegend
+        showLegend={showLegend}
         legendPosition="top"
         onBrushEnd={action('onBrushEnd')}
         brushAxis="both"

--- a/stories/heatmap/1_basic.tsx
+++ b/stories/heatmap/1_basic.tsx
@@ -18,7 +18,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { boolean, button, select } from '@storybook/addon-knobs';
+import { boolean, button, select, number } from '@storybook/addon-knobs';
 import React, { useCallback, useMemo, useState } from 'react';
 import { debounce } from 'ts-debounce';
 
@@ -35,21 +35,25 @@ import {
 import { Config } from '../../packages/charts/src/chart_types/heatmap/layout/types/config_types';
 import { SWIM_LANE_DATA } from '../../packages/charts/src/utils/data_samples/test_anomaly_swim_lane';
 
+const X_AXIS = 'X Axis';
+
 export const Example = () => {
   const [selection, setSelection] = useState<{ x: (string | number)[]; y: (string | number)[] } | undefined>();
 
   const persistCellsSelection = boolean('Persist cells selection', true);
   const debugState = boolean('Enable debug state', true);
   const dataStateAction = action('DataState');
-  const xAxisVisible = boolean('X Axis visible', true);
-  const xAxisLabelRotation = select('X Axis Label Rotation', [0, 90, -90, 180], 0);
-  const xAxisPosition = select('X Axis Position', ['top', 'bottom'], 'top');
   const showLegend = boolean('Show Legend', false);
   const handler = useCallback(() => {
     setSelection(undefined);
   }, []);
 
   button('Clear cells selection', handler);
+
+  const xAxisVisible = boolean('X Axis visible', true, X_AXIS);
+  const xAxisLabelRotation = select('X Axis Label Rotation', [0, 90, -90, 180], 0, X_AXIS);
+  const xAxisPosition = select('X Axis Position', ['top', 'bottom'], 'top', X_AXIS);
+  const xAxisPadding = number('X Axis padding', 0, { range: true, min: 0, max: 30, step: 1 }, X_AXIS);
 
   const config: RecursivePartial<Config> = useMemo(
     () => ({
@@ -82,6 +86,7 @@ export const Example = () => {
         visible: xAxisVisible,
         labelRotation: xAxisLabelRotation,
         position: xAxisPosition,
+        padding: xAxisPadding,
         formatter: (value: string | number) => {
           return niceTimeFormatter([1572825600000, 1572912000000])(value, { timeZone: 'UTC' });
         },
@@ -90,7 +95,7 @@ export const Example = () => {
         setSelection({ x: e.x, y: e.y });
       }) as Config['onBrushEnd'],
     }),
-    [xAxisVisible, xAxisLabelRotation, xAxisPosition],
+    [xAxisVisible, xAxisLabelRotation, xAxisPosition, xAxisPadding],
   );
 
   const logDebugstate = debounce(() => {

--- a/stories/heatmap/1_basic.tsx
+++ b/stories/heatmap/1_basic.tsx
@@ -41,7 +41,7 @@ export const Example = () => {
   const persistCellsSelection = boolean('Persist cells selection', true);
   const debugState = boolean('Enable debug state', true);
   const dataStateAction = action('DataState');
-
+  const xAxisVisible = boolean('X Axis visible', true);
   const handler = useCallback(() => {
     setSelection(undefined);
   }, []);
@@ -52,7 +52,7 @@ export const Example = () => {
     () => ({
       grid: {
         cellHeight: {
-          min: 20,
+          min: 10,
         },
         stroke: {
           width: 1,
@@ -76,6 +76,7 @@ export const Example = () => {
         padding: { left: 10, right: 10 },
       },
       xAxisLabel: {
+        visible: xAxisVisible,
         formatter: (value: string | number) => {
           return niceTimeFormatter([1572825600000, 1572912000000])(value, { timeZone: 'UTC' });
         },
@@ -84,7 +85,7 @@ export const Example = () => {
         setSelection({ x: e.x, y: e.y });
       }) as Config['onBrushEnd'],
     }),
-    [],
+    [xAxisVisible],
   );
 
   const logDebugstate = debounce(() => {


### PR DESCRIPTION
Allow for the x axis of the heatmap to be either on the top or bottom of the heatmap. Allow for rotating the tick labels at any multiple of 90 degrees.

Features:

- [x] Tick label rotation
- [x] X Axis placement
- [x] Properly support the highlighting brush
- [x] Add options to storybook example
- [x] Correctly use any padding and margin styling (while there is a margin option available, it is currently not implemented at all, so it was ignored)
- [x] Pass existing tests
- [x] Create new tests