### PR TITLE
fix(xy): labelformatter overlap fix

### DIFF
--- a/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick_label.ts
+++ b/packages/charts/src/chart_types/xy_chart/renderer/canvas/axes/tick_label.ts
@@ -102,7 +102,7 @@ export function renderTickLabel(ctx: CanvasRenderingContext2D, tick: AxisTick, s
         x: x + offsetX,
         y: y + offsetY,
       },
-      labelFormat ? labelFormat(tick.value) : tick.label,
+      labelFormat && tick.label ? labelFormat(tick.value) : tick.label,
       {
         ...font,
         fontSize: labelStyle.fontSize,


### PR DESCRIPTION
fix(xy): labelFormat do not ignore blank tick label avoiding overlapped labels.