### PR TITLE
Fix/gauge - add better config support

### DIFF
--- a/packages/charts/src/chart_types/goal_chart/layout/config/config.ts
+++ b/packages/charts/src/chart_types/goal_chart/layout/config/config.ts
@@ -51,6 +51,9 @@ export const configMetadata: Record<string, ConfigItem> = {
 
   backgroundColor: { dflt: '#ffffff', type: 'color' },
   sectorLineWidth: { dflt: 1, min: 0, max: 4, type: 'number' },
+
+  actualFillColor: { dflt: 'black', type: 'color' },
+  targetFillColor: { dflt: 'black', type: 'color' },
 };
 
 /** @internal */

--- a/packages/charts/src/chart_types/goal_chart/layout/types/config_types.ts
+++ b/packages/charts/src/chart_types/goal_chart/layout/types/config_types.ts
@@ -42,4 +42,8 @@ export interface Config {
   // other
   backgroundColor: Color;
   sectorLineWidth: Pixels;
+
+  // colors
+  actualFillColor: Color;
+  targetFillColor: Color;
 }

--- a/packages/charts/src/chart_types/goal_chart/layout/types/viewmodel_types.ts
+++ b/packages/charts/src/chart_types/goal_chart/layout/types/viewmodel_types.ts
@@ -40,7 +40,7 @@ interface TickViewModel {
 export interface BulletViewModel {
   subtype: string;
   base: number;
-  target: number;
+  target?: number;
   actual: number;
   bands: Array<BandViewModel>;
   ticks: Array<TickViewModel>;

--- a/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
@@ -44,8 +44,9 @@ export function renderCanvas2d(
   dpr: number,
   { config, bulletViewModel, chartCenter }: ShapeViewModel,
 ) {
-  // eslint-disable-next-line no-empty-pattern
-  const {} = config;
+  // const { fontFamily } = config;
+
+  const fontFamily = get(config, 'fontFamily', 'sans-serif');
 
   withContext(ctx, (ctx) => {
     // set some defaults for the overall rendering
@@ -139,11 +140,15 @@ export function renderCanvas2d(
         landmarks: { from: 'base', to: 'actual' },
         aes: { shape: 'line', fillColor: 'black', lineWidth: tickLength },
       },
-      {
-        order: 2,
-        landmarks: { at: 'target' },
-        aes: { shape: 'line', fillColor: 'black', lineWidth: barThickness / GOLDEN_RATIO },
-      },
+      ...(target
+        ? [
+            {
+              order: 2,
+              landmarks: { at: 'target' },
+              aes: { shape: 'line', fillColor: 'black', lineWidth: barThickness / GOLDEN_RATIO },
+            },
+          ]
+        : []),
       ...bulletViewModel.ticks.map((b, i) => ({
         order: 3,
         landmarks: { at: `tick_${i}` },
@@ -162,7 +167,7 @@ export function renderCanvas2d(
           textAlign: vertical ? 'right' : 'center',
           textBaseline: vertical ? 'middle' : 'top',
           fillColor: 'black',
-          fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '500', fontFamily: 'sans-serif' },
+          fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '500', fontFamily },
           axisNormalOffset: -barThickness,
         },
       })),
@@ -176,7 +181,7 @@ export function renderCanvas2d(
           textAlign: vertical ? 'center' : 'right',
           textBaseline: 'bottom',
           fillColor: 'black',
-          fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '900', fontFamily: 'sans-serif' },
+          fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '900', fontFamily },
         },
       },
       {
@@ -189,7 +194,7 @@ export function renderCanvas2d(
           textAlign: vertical ? 'center' : 'right',
           textBaseline: 'top',
           fillColor: 'black',
-          fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '300', fontFamily: 'sans-serif' },
+          fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '300', fontFamily },
         },
       },
       ...(circular
@@ -202,7 +207,7 @@ export function renderCanvas2d(
                 textAlign: 'center',
                 textBaseline: 'bottom',
                 fillColor: 'black',
-                fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '900', fontFamily: 'sans-serif' },
+                fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '900', fontFamily },
               },
             },
             {
@@ -213,7 +218,7 @@ export function renderCanvas2d(
                 textAlign: 'center',
                 textBaseline: 'top',
                 fillColor: 'black',
-                fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '300', fontFamily: 'sans-serif' },
+                fontShape: { fontStyle: 'normal', fontVariant: 'normal', fontWeight: '300', fontFamily },
               },
             },
           ]

--- a/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/goal_chart/renderer/canvas/canvas_renderers.ts
@@ -47,6 +47,8 @@ export function renderCanvas2d(
   // const { fontFamily } = config;
 
   const fontFamily = get(config, 'fontFamily', 'sans-serif');
+  const actualFillColor = get(config, 'actualFillColor', 'black');
+  const targetFillColor = get(config, 'targetFillColor', 'black');
 
   withContext(ctx, (ctx) => {
     // set some defaults for the overall rendering
@@ -138,14 +140,14 @@ export function renderCanvas2d(
       {
         order: 1,
         landmarks: { from: 'base', to: 'actual' },
-        aes: { shape: 'line', fillColor: 'black', lineWidth: tickLength },
+        aes: { shape: 'line', fillColor: actualFillColor, lineWidth: tickLength },
       },
       ...(target
         ? [
             {
               order: 2,
               landmarks: { at: 'target' },
-              aes: { shape: 'line', fillColor: 'black', lineWidth: barThickness / GOLDEN_RATIO },
+              aes: { shape: 'line', fillColor: targetFillColor, lineWidth: barThickness / GOLDEN_RATIO },
             },
           ]
         : []),

--- a/packages/charts/src/chart_types/goal_chart/state/selectors/get_goal_chart_data.ts
+++ b/packages/charts/src/chart_types/goal_chart/state/selectors/get_goal_chart_data.ts
@@ -24,7 +24,7 @@ import { geometries } from './geometries';
 export type GoalChartData = {
   maximum: number;
   minimum: number;
-  target: number;
+  target?: number;
   value: number;
 };
 


### PR DESCRIPTION
## Summary

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [ ] The proper feature label was added (e.g. :interactions, :axis) if the PR involves a specific chart feature
- [ ] Whenever possible, please check if the closing issue is connected to a running GH project
- [ ] Any consumer-facing exports were added to `packages/charts/src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
